### PR TITLE
Allow slashes in keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    translations_checker (1.2.11)
+    translations_checker (1.2.12)
       activesupport (>= 4.2.9)
       naught (~> 1.1.0)
 

--- a/lib/translations_checker/diff_block.rb
+++ b/lib/translations_checker/diff_block.rb
@@ -46,7 +46,7 @@ module TranslationsChecker
       counters = { "-" => old_line - 1, "+" => new_line - 1 }
       proc do |line|
         counters[line[0]] += 1
-        change_type, key = line.scan(/^([+-])\s*(\w+):/).flatten
+        change_type, key = line.scan(%r{^([+-])\s*(\w[/\w]+):}).flatten
         [key, counters[change_type], change_type] if change_type
       end
     end

--- a/lib/translations_checker/locale_file_key_map.rb
+++ b/lib/translations_checker/locale_file_key_map.rb
@@ -22,7 +22,7 @@ module TranslationsChecker
 
     def key_lines
       lines.each_with_index.map do |line, index|
-        indent, key = line.scan(/(\A\s*)(?:(\w+):)?/).flatten
+        indent, key = line.scan(%r{(\A\s*)(?:(\w[/\w]+):)?}).flatten
         [index + 1, indent.size / 2, key]
       end.select(&:last)
     end

--- a/lib/translations_checker/version.rb
+++ b/lib/translations_checker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TranslationsChecker
-  VERSION = "1.2.11"
+  VERSION = "1.2.12"
 end

--- a/spec/lib/translations_checker/diff_block_spec.rb
+++ b/spec/lib/translations_checker/diff_block_spec.rb
@@ -26,6 +26,26 @@ RSpec.describe TranslationsChecker::DiffBlock do
       end
     end
 
+    context "when there are keys containing slashes" do
+      let(:body) do
+        <<~BODY
+          -  key/1: Old value 1
+          -  key/2: Old value 2
+          +  key/1: New value 1
+          +  key/2: New value 2
+        BODY
+      end
+
+      let(:diff_block) { described_class.new(file_diff, 8, 4, body) }
+
+      it "returns the changes" do
+        changes = [ double(:first_change), double(:second_change) ]
+        allow(TranslationsChecker::Change).to receive(:new).with(file_diff, "key/1", "-" => 8, "+" => 4).and_return changes[0]
+        allow(TranslationsChecker::Change).to receive(:new).with(file_diff, "key/2", "-" => 9, "+" => 5).and_return changes[1]
+        expect(diff_block.changes).to eq changes
+      end
+    end
+
     context "when a key has been removed" do
       let(:body) do
         <<~BODY

--- a/spec/lib/translations_checker/locale_file_key_map_spec.rb
+++ b/spec/lib/translations_checker/locale_file_key_map_spec.rb
@@ -83,6 +83,21 @@ RSpec.describe TranslationsChecker::LocaleFileKeyMap do
         expect(key_map.key_at(6)).to be_nil
       end
     end
+
+    context "given a line nested inside a key containing slashes" do
+      let(:yaml) do
+        <<~YAML
+          root:
+            parent/1:
+              child_1: "child 1"
+              child_2: "child 2"
+        YAML
+      end
+
+      it "returns the full key for the given line number" do
+        expect(key_map.key_at(4)).to eq %w(root parent/1 child_2)
+      end
+    end
   end
 
   describe "#key_line" do


### PR DESCRIPTION
Fixes a bug that would cause crashes when handling changes in keys containing slashes, or keys nested inside keys containing slashes.