### PR TITLE
Improve handling of deletions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    translations_checker (1.3.0)
+    translations_checker (1.3.4)
       activesupport (>= 4.2.9)
       naught (~> 1.1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    translations_checker (1.2.12)
+    translations_checker (1.3.0)
       activesupport (>= 4.2.9)
       naught (~> 1.1.0)
 

--- a/lib/translations_checker/change.rb
+++ b/lib/translations_checker/change.rb
@@ -6,7 +6,8 @@ module TranslationsChecker
   class Change
     attr_reader :file_diff, :name, :new_line, :old_line
 
-    delegate :locale, to: :file_diff
+    delegate :locale, :locale_file,                                to: :file_diff
+    delegate :old_key_at, :new_key_at, :old_content, :new_content, to: :locale_file
 
     def initialize(file_diff, name, change)
       @file_diff = file_diff
@@ -14,16 +15,20 @@ module TranslationsChecker
       @new_line, @old_line = change.values_at("+", "-")
     end
 
-    def new_value
-      deleted? ? nil : file_diff.locale_file[full_key]
+    def full_key
+      deleted? ? old_key_at(old_line) : new_key_at(new_line)
     end
 
-    def full_key
-      file_diff.locale_file.key_at(new_line)
+    def new_value
+      deleted? ? nil : new_content[full_key]
+    end
+
+    def old_value
+      added? ? nil : old_content[full_key]
     end
 
     def display_key
-      deleted? ? [name] : full_key.drop(1)
+      full_key.drop(1)
     end
 
     # :reek:NilCheck

--- a/lib/translations_checker/change.rb
+++ b/lib/translations_checker/change.rb
@@ -1,5 +1,3 @@
-require "naught"
-
 require "active_support/all"
 
 module TranslationsChecker
@@ -58,28 +56,6 @@ module TranslationsChecker
 
     def ==(other)
       file_diff == other.file_diff && name == other.name && old_line == other.old_line && new_line == other.new_line
-    end
-  end
-
-  # TODO: I'm being a bit lazy here - I'm using the naught gem, even though this doesn't exactly fit the usual
-  #       null-object pattern
-  NoChange = Naught.build do |config|
-    config.predicates_return false
-    config.mimic Change
-
-    attr_reader :file_diff, :full_key
-
-    def initialize(file_diff, full_key)
-      @file_diff = file_diff
-      @full_key = full_key
-    end
-
-    def name
-      full_key.last
-    end
-
-    def display_key
-      full_key.drop([1, full_key.size - 1].min)
     end
   end
 end

--- a/lib/translations_checker/checker.rb
+++ b/lib/translations_checker/checker.rb
@@ -1,4 +1,5 @@
 require "translations_checker/diff"
+require "translations_checker/empty_diff"
 require "translations_checker/issues_presenter"
 require "translations_checker/terminal_colours"
 require "translations_checker/indentation"
@@ -58,7 +59,7 @@ module TranslationsChecker
     end
 
     def diff_for_locale_file(locale_file)
-      diffs.detect { |diff| diff.locale_file == locale_file } || EmptyDiff.new(locale_file)
+      diffs.detect { |diff| diff.locale_file == locale_file } || EmptyDiff.new(locale_file.path)
     end
 
     def locales

--- a/lib/translations_checker/diff.rb
+++ b/lib/translations_checker/diff.rb
@@ -1,5 +1,6 @@
 require "translations_checker/locale_file"
 require "translations_checker/diff_block"
+require "translations_checker/no_change"
 
 require "active_support/all"
 
@@ -29,17 +30,11 @@ module TranslationsChecker
     # :reek:FeatureEnvy
     def match_change(other_change)
       this_change = changes.detect(&other_change.method(:matches?))
-      this_change || NoChange.new(self, other_change.full_key || other_change.name)
+      this_change || NoChange.new(self, [locale, *other_change.full_key.drop(1)])
     end
 
     def match_changes(other_diff)
       changes.zip(changes.map(&other_diff.method(:match_change)))
-    end
-  end
-
-  class EmptyDiff < Diff
-    def initialize(path)
-      super(path, [])
     end
   end
 end

--- a/lib/translations_checker/empty_diff.rb
+++ b/lib/translations_checker/empty_diff.rb
@@ -1,0 +1,9 @@
+require "translations_checker/diff"
+
+module TranslationsChecker
+  class EmptyDiff < Diff
+    def initialize(path)
+      super(path, [])
+    end
+  end
+end

--- a/lib/translations_checker/git_show.rb
+++ b/lib/translations_checker/git_show.rb
@@ -6,9 +6,14 @@ module TranslationsChecker
 
     attr_reader :path, :ref
 
-    def initialize(path, ref: "HEAD")
+    REF_ALIASES = {
+      current:  "HEAD",
+      original: "$(git merge-base origin/master HEAD)"
+    }.freeze
+
+    def initialize(path, ref: :current)
       @path = path
-      @ref = ref
+      @ref = REF_ALIASES.fetch(ref, ref)
     end
 
     def call

--- a/lib/translations_checker/issue.rb
+++ b/lib/translations_checker/issue.rb
@@ -4,7 +4,8 @@ module TranslationsChecker
   class Issue
     attr_reader :change, :locale_change
 
-    delegate :display_key, to: :change
+    delegate :display_key, :locale_file, :locale, to: :change
+    delegate :new_key_line,                       to: :locale_file
 
     def initialize(change, locale_change)
       @change = change
@@ -32,7 +33,7 @@ module TranslationsChecker
     end
 
     def new_destination_line
-      locale_change.new_line
+      locale_change.new_line || new_key_line([locale, *display_key])
     end
 
     def old_destination_line

--- a/lib/translations_checker/locale_file.rb
+++ b/lib/translations_checker/locale_file.rb
@@ -11,8 +11,8 @@ module TranslationsChecker
     attr_reader :path
 
     delegate :exist?, :to_s, to: :path
-    delegate :key_at,        to: :new_key_map, prefix: :new
-    delegate :key_at,        to: :old_key_map, prefix: :old
+    delegate :key_at, :key_line, to: :new_key_map, prefix: :new
+    delegate :key_at, :key_line, to: :old_key_map, prefix: :old
 
     def initialize(path)
       @path = Pathname(path)

--- a/lib/translations_checker/locale_file.rb
+++ b/lib/translations_checker/locale_file.rb
@@ -11,8 +11,8 @@ module TranslationsChecker
     attr_reader :path
 
     delegate :exist?, :to_s, to: :path
-    delegate :key_at,        to: :key_map
-    delegate :[],            to: :content
+    delegate :key_at,        to: :new_key_map, prefix: :new
+    delegate :key_at,        to: :old_key_map, prefix: :old
 
     def initialize(path)
       @path = Pathname(path)
@@ -37,12 +37,20 @@ module TranslationsChecker
       path == other.path
     end
 
-    def content
-      @content ||= LocaleFileContent.new(GitShow.call(path))
+    def new_content
+      @new_content ||= LocaleFileContent.new(GitShow.call(path))
     end
 
-    def key_map
-      @key_map ||= LocaleFileKeyMap.new(content)
+    def new_key_map
+      @new_key_map ||= LocaleFileKeyMap.new(new_content)
+    end
+
+    def old_content
+      @old_content ||= LocaleFileContent.new(GitShow.call(path, ref: :original))
+    end
+
+    def old_key_map
+      @old_key_map ||= LocaleFileKeyMap.new(old_content)
     end
 
     private

--- a/lib/translations_checker/no_change.rb
+++ b/lib/translations_checker/no_change.rb
@@ -1,0 +1,33 @@
+require "translations_checker/change"
+
+require "naught"
+
+module TranslationsChecker
+  # TODO: I'm being a bit lazy here - I'm using the naught gem, even though this doesn't exactly fit the usual
+  #       null-object pattern
+  NoChange = Naught.build do |config|
+    config.predicates_return false
+    config.mimic Change
+
+    attr_reader :file_diff, :full_key
+
+    delegate :locale, :locale_file, to: :file_diff
+
+    def initialize(file_diff, full_key)
+      @file_diff = file_diff
+      @full_key = full_key
+    end
+
+    def name
+      full_key.last
+    end
+
+    def display_key
+      full_key.drop(1)
+    end
+
+    def new_line
+      locale_file.new_key_line(full_key)
+    end
+  end
+end

--- a/lib/translations_checker/version.rb
+++ b/lib/translations_checker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TranslationsChecker
-  VERSION = "1.3.0"
+  VERSION = "1.3.4"
 end

--- a/lib/translations_checker/version.rb
+++ b/lib/translations_checker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TranslationsChecker
-  VERSION = "1.2.12"
+  VERSION = "1.3.0"
 end

--- a/spec/lib/translations_checker/change_checker_spec.rb
+++ b/spec/lib/translations_checker/change_checker_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 require "translations_checker/change"
+require "translations_checker/no_change"
 require "translations_checker/change_checker"
 
 RSpec.describe TranslationsChecker::ChangeChecker do

--- a/spec/lib/translations_checker/change_spec.rb
+++ b/spec/lib/translations_checker/change_spec.rb
@@ -72,7 +72,21 @@ RSpec.describe TranslationsChecker::Change do
   end
 
   describe "#display_key" do
-    it "returns the full key without the locale name"
+    it "returns the full key without the locale name" do
+      change = described_class.new(nil, nil, {})
+      allow(change).to receive(:full_key).and_return %w(xx yy zz)
+
+      expect(change.display_key).to eq %w(yy zz)
+    end
+
+    context "when the full key is empty" do
+      it "returns an empty key" do
+        change = described_class.new(nil, nil, {})
+        allow(change).to receive(:full_key).and_return []
+
+        expect(change.display_key).to eq []
+      end
+    end
   end
 
   context "when a value has been added" do

--- a/spec/lib/translations_checker/change_spec.rb
+++ b/spec/lib/translations_checker/change_spec.rb
@@ -4,21 +4,75 @@ require "translations_checker/change"
 
 RSpec.describe TranslationsChecker::Change do
   describe "#new_value" do
-    it "returns the value from the new version of the locale file"
+    context "for a deletion" do
+      it "returns nil" do
+        change = described_class.new(nil, nil, "-" => 321)
+        expect(change.new_value).to be_nil
+      end
+    end
+
+    context "for a non-deletion" do
+      it "returns the value from the new version of the locale file", :aggregate_failures do
+        change = described_class.new(nil, nil, "-" => 123, "+" => 456)
+        new_content = instance_double TranslationsChecker::LocaleFileContent
+        expected_value = double :value
+        key = double :key
+        allow(change).to receive(:full_key).and_return key
+        allow(change).to receive(:new_content).and_return new_content
+
+        expect(new_content).to receive(:[]).with(key).and_return expected_value
+        expect(change.new_value).to be expected_value
+      end
+    end
+  end
+
+  describe "#old_value" do
+    context "for an addition" do
+      it "returns nil" do
+        change = described_class.new(nil, nil, "+" => 321)
+        expect(change.old_value).to be_nil
+      end
+    end
+
+    context "for a non-addition" do
+      it "returns the value from the old version of the locale file", :aggregate_failures do
+        change = described_class.new(nil, nil, "-" => 123, "+" => 456)
+        old_content = instance_double TranslationsChecker::LocaleFileContent
+        expected_value = double :value
+        key = double :key
+        allow(change).to receive(:full_key).and_return key
+        allow(change).to receive(:old_content).and_return old_content
+
+        expect(old_content).to receive(:[]).with(key).and_return expected_value
+        expect(change.old_value).to be expected_value
+      end
+    end
   end
 
   describe "#full_key" do
-    it "returns the full key for the changed value"
+    context "for a non-deletion" do
+      it "returns the full key from the new version", :aggregate_failures do
+        change = described_class.new(nil, nil, "-" => 123, "+" => 456)
+        expected_key = double :key
+
+        expect(change).to receive(:new_key_at).with(456).and_return expected_key
+        expect(change.full_key).to be expected_key
+      end
+    end
+
+    context "for a deletion" do
+      it "returns the full key from the old version", :aggregate_failures do
+        change = described_class.new(nil, nil, "-" => 321)
+        expected_key = double :key
+
+        expect(change).to receive(:old_key_at).with(321).and_return expected_key
+        expect(change.full_key).to be expected_key
+      end
+    end
   end
 
   describe "#display_key" do
-    context "when there is a full key" do
-      it "returns the full key for the changed value without the locale name"
-    end
-
-    context "when there is not a full key" do
-      it "returns the name for the changed value"
-    end
+    it "returns the full key without the locale name"
   end
 
   context "when a value has been added" do

--- a/spec/lib/translations_checker/diff_spec.rb
+++ b/spec/lib/translations_checker/diff_spec.rb
@@ -64,38 +64,21 @@ RSpec.describe TranslationsChecker::Diff do
 
     context "when there is no matching change" do
       context "when the other change has a full key" do
-        it "returns a 'no change' object with the full key", :aggregate_failures do
+        it "returns a 'no change' object with the full key in this locale", :aggregate_failures do
           other_change = instance_double(
             "TranslationsChecker::Change",
             :other_change,
             matches?: false,
-            full_key: %w(xx yy)
+            full_key: %w(zz yy)
           )
           diff = described_class.new("xx/yy.yml", [])
+          allow(diff).to receive(:locale).and_return "zz"
 
           no_change = instance_double "TranslationsChecker::NoChange", :no_change
 
-          expect(TranslationsChecker::NoChange).to receive(:new).with(diff, %w(xx yy)).and_return no_change
+          expect(TranslationsChecker::NoChange).to receive(:new).with(diff, %w(zz yy)).and_return no_change
           expect(diff.match_change(other_change)).to be no_change
         end
-      end
-    end
-
-    context "when the other change does not have a full key" do
-      it "returns a 'no change' object with the name", :aggregate_failures do
-        other_change = instance_double(
-          "TranslationsChecker::Change",
-          :other_change,
-          matches?: false,
-          full_key: nil,
-          name:     "xx"
-        )
-        diff = described_class.new("xx/yy.yml", [])
-
-        no_change = instance_double "TranslationsChecker::NoChange", :no_change
-
-        expect(TranslationsChecker::NoChange).to receive(:new).with(diff, "xx").and_return no_change
-        expect(diff.match_change(other_change)).to be no_change
       end
     end
   end

--- a/spec/lib/translations_checker/locale_file_spec.rb
+++ b/spec/lib/translations_checker/locale_file_spec.rb
@@ -85,55 +85,55 @@ RSpec.describe TranslationsChecker::LocaleFile do
     end
   end
 
-  describe "#content" do
+  describe "#new_content" do
     let(:path) { fixture_dir.join("xx/xx.yml") }
 
-    it "returns a locale file content object built from the locale file's contents fetched using `git show`", :aggregate_failures do
+    it "returns a locale file content object built from the locale file's new contents", :aggregate_failures do
       file_content = path.read
       expected_locale_file_content = double :locale_file_content
 
       expect(TranslationsChecker::GitShow).to receive(:call).with(path).and_return file_content
       expect(TranslationsChecker::LocaleFileContent).to receive(:new).with(file_content).and_return(expected_locale_file_content)
-      expect(locale_file.content).to be expected_locale_file_content
+      expect(locale_file.new_content).to be expected_locale_file_content
     end
   end
 
-  describe "#[]" do
+  describe "#new_key_map" do
     let(:path) { "xx/yy.yml" }
 
-    it "delegates to the locale file's content" do
-      expected_value = double :value
-      content = instance_double "TranslationsChecker::LocaleFileContent", :locale_file_content
-      allow(locale_file).to receive(:content).and_return(content)
-
-      expect(content).to receive(:[]).with(%w(en hello)).and_return(expected_value)
-      expect(locale_file[%w(en hello)]).to be expected_value
-    end
-  end
-
-  describe "#key_map" do
-    let(:path) { "xx/yy.yml" }
-
-    it "returns a locale file key map object built from the locale file's contents", :aggregate_failures do
+    it "returns a locale file key map object built from the locale file's new contents", :aggregate_failures do
       locale_file_content = instance_double "TranslationsChecker::LocaleFileContent", :locale_file_content
       expected_locale_file_key_map = double :locale_file_key_map
 
-      expect(locale_file).to receive(:content).and_return(locale_file_content)
+      expect(locale_file).to receive(:new_content).and_return(locale_file_content)
       expect(TranslationsChecker::LocaleFileKeyMap).to receive(:new).with(locale_file_content).and_return(expected_locale_file_key_map)
-      expect(locale_file.key_map).to be expected_locale_file_key_map
+      expect(locale_file.new_key_map).to be expected_locale_file_key_map
     end
   end
 
-  describe "#key_at" do
+  describe "#old_content" do
+    let(:path) { fixture_dir.join("xx/xx.yml") }
+
+    it "returns a locale file content object built from the locale file's old contents", :aggregate_failures do
+      file_content = path.read
+      expected_locale_file_content = double :locale_file_content
+
+      expect(TranslationsChecker::GitShow).to receive(:call).with(path, ref: :original).and_return file_content
+      expect(TranslationsChecker::LocaleFileContent).to receive(:new).with(file_content).and_return(expected_locale_file_content)
+      expect(locale_file.old_content).to be expected_locale_file_content
+    end
+  end
+
+  describe "#old_key_map" do
     let(:path) { "xx/yy.yml" }
 
-    it "delegates to the locale file's key map" do
-      expected_key = double :key
-      key_map = instance_double "TranslationsChecker::LocaleFileKeyMap", :locale_file_key_map
-      allow(locale_file).to receive(:key_map).and_return(key_map)
+    it "returns a locale file key map object built from the locale file's old contents", :aggregate_failures do
+      locale_file_content = instance_double "TranslationsChecker::LocaleFileContent", :locale_file_content
+      expected_locale_file_key_map = double :locale_file_key_map
 
-      expect(key_map).to receive(:key_at).with(12).and_return(expected_key)
-      expect(locale_file.key_at(12)).to be expected_key
+      expect(locale_file).to receive(:old_content).and_return(locale_file_content)
+      expect(TranslationsChecker::LocaleFileKeyMap).to receive(:new).with(locale_file_content).and_return(expected_locale_file_key_map)
+      expect(locale_file.old_key_map).to be expected_locale_file_key_map
     end
   end
 end

--- a/spec/lib/translations_checker/no_change_spec.rb
+++ b/spec/lib/translations_checker/no_change_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+require "translations_checker/no_change"
+
+RSpec.describe TranslationsChecker::NoChange do
+  describe "#name" do
+    it "returns the last component of the full key" do
+      expected_name = double :name
+      change = described_class.new(nil, ["xx", "yy", expected_name])
+
+      expect(change.name).to be expected_name
+    end
+  end
+
+  describe "#display_key" do
+    it "returns the full key without the locale name" do
+      change = described_class.new(nil, %w(xx yy zz))
+
+      expect(change.display_key).to eq %w(yy zz)
+    end
+
+    context "when the full key is empty" do
+      it "returns an empty key" do
+        change = described_class.new(nil, [])
+
+        expect(change.display_key).to eq []
+      end
+    end
+  end
+
+  describe "#new_line" do
+    it "uses the key line from the file content" do
+      locale_file = instance_double TranslationsChecker::LocaleFile, :locale_file
+      full_key = double :full_key
+      change = described_class.new(nil, full_key)
+      allow(change).to receive(:locale_file).and_return locale_file
+      expected_line_number = double :line_number
+
+      expect(locale_file).to receive(:new_key_line).and_return expected_line_number
+      expect(change.new_line).to be expected_line_number
+    end
+  end
+end
+


### PR DESCRIPTION
This PR improves the way deletions are handle. It now shows the full key for keys deleted in the `en` locale and shows the destination line number for the translated locale. It no also shows the destination line number for keys modified in the `en` locale, but not in the translated locale.