### PR TITLE
Ignore changes on non-string values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    translations_checker (1.3.4)
+    translations_checker (1.3.5)
       activesupport (>= 4.2.9)
       naught (~> 1.1.0)
 

--- a/lib/translations_checker/change_checker.rb
+++ b/lib/translations_checker/change_checker.rb
@@ -5,6 +5,10 @@ module TranslationsChecker
   ChangeChecker = Struct.new(:this_change, :other_change) do
     include Concerns::Service
 
+    def not_a_string
+      return NonIssue.new unless this_change.new_value.is_a?(String)
+    end
+
     def not_deleted
       return unless this_change.deleted?
       return NonIssue.new if other_change.deleted?
@@ -29,7 +33,7 @@ module TranslationsChecker
     end
 
     def call
-      not_deleted || missing_or_unchanged || incorrect_format
+      not_a_string || not_deleted || missing_or_unchanged || incorrect_format
     end
   end
 end

--- a/lib/translations_checker/version.rb
+++ b/lib/translations_checker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TranslationsChecker
-  VERSION = "1.3.4"
+  VERSION = "1.3.5"
 end

--- a/spec/lib/translations_checker/no_change_spec.rb
+++ b/spec/lib/translations_checker/no_change_spec.rb
@@ -41,4 +41,3 @@ RSpec.describe TranslationsChecker::NoChange do
     end
   end
 end
-


### PR DESCRIPTION
Fixes a bug where a changes to non-string values would cause incorrect format errors. For example, the following changes:

```
diff --git a/config/locales/en/activerecord.yml b/config/locales/en/activerecord.yml
index ce6245763..fa984fdf2 100644
--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -46,6 +46,8 @@ en:
         code: Code
       company_travel_doctor:
         phone: Phone
+      itinerary_quote:
+        pnr: PNR
       country_risk_list:
         name: Name
       country_risk_list_item:
diff --git a/config/locales/ja/activerecord.yml b/config/locales/ja/activerecord.yml
index db3b68d9e..e5ecc0424 100644
--- a/config/locales/ja/activerecord.yml
+++ b/config/locales/ja/activerecord.yml
@@ -47,6 +47,8 @@ ja:
         code: "コード"
       company_travel_doctor:
         phone: "電話番号"
+      itinerary_quote:
+        pnr: "[JA] PNR"
       country_risk_list:
         name: "国名"
       country_risk_list_item:
```

Would produce this error:

![image](https://user-images.githubusercontent.com/322950/33961135-2e3e6168-e00a-11e7-977d-0c2b404d10e7.png)

The problem is that the value at `activerecord.attributes.itinerary_quote` is being treated as a string value when it should be ignored.