### PR TITLE
LM-7416 Update translations_checker script so it doesn't break when .rb locale is added/changed

### DIFF
--- a/lib/translations_checker/checker.rb
+++ b/lib/translations_checker/checker.rb
@@ -14,6 +14,8 @@ module TranslationsChecker
 
     using Indentation
 
+    SUPPORTED_FORMATS = %w(yml).freeze
+
     # :reek:TooManyStatements
     def call
       if issues.empty?
@@ -70,10 +72,18 @@ module TranslationsChecker
       @translated_locales ||= locales - %w(en en-AU)
     end
 
+    def git_diffs
+      GitDiff.call(LOCALES_DIR)
+    end
+
     def diffs
-      @diffs ||= GitDiff.call(LOCALES_DIR).map do |path, hunks|
+      @diffs ||= supported_git_diffs.map do |path, hunks|
         Diff.new(path, hunks)
       end
+    end
+
+    def supported_git_diffs
+      git_diffs.select{|path, hunks| SUPPORTED_FORMATS.include?(path.split('.')[-1])}
     end
 
     # :reek:FeatureEnvy

--- a/lib/translations_checker/checker.rb
+++ b/lib/translations_checker/checker.rb
@@ -14,7 +14,7 @@ module TranslationsChecker
 
     using Indentation
 
-    SUPPORTED_FORMATS = %w(yml).freeze
+    SUPPORTED_FORMATS = %w(.yml).freeze
 
     # :reek:TooManyStatements
     def call

--- a/lib/translations_checker/checker.rb
+++ b/lib/translations_checker/checker.rb
@@ -83,7 +83,7 @@ module TranslationsChecker
     end
 
     def supported_git_diffs
-      git_diffs.select{|path, hunks| SUPPORTED_FORMATS.include?(path.split('.')[-1])}
+      git_diffs.select { |path, hunks| SUPPORTED_FORMATS.include?(path.split('.').last) }
     end
 
     # :reek:FeatureEnvy

--- a/lib/translations_checker/checker.rb
+++ b/lib/translations_checker/checker.rb
@@ -83,7 +83,7 @@ module TranslationsChecker
     end
 
     def supported_git_diffs
-      git_diffs.select { |path, hunks| SUPPORTED_FORMATS.include?(path.split('.').last) }
+      git_diffs.select { |path, _| SUPPORTED_FORMATS.include?(File.extname(path)) }
     end
 
     # :reek:FeatureEnvy


### PR DESCRIPTION
# [LM-7416](https://locomote.atlassian.net/browse/LM-7416)

Spike: [LM-7291](https://locomote.atlassian.net/browse/LM-7291)

# Background

Lets say we have a date 01.10.2018. and time 10:30. Before this card it displayed "10:30am 1th June 2018" (notice 'th'), and after: "10:30am 1st June 2018".

There is no format that would achieve that in Rails, so we can't just use a string locale, we need to pass a lambda and make our own. In order to do that we need to have a locale file with .rb extension. There already is one, with a similar format, we just need to append the new format (config/locales/en/date_formats.rb).

It works locally, but problem is that now we have a translations_checker pre-push script (https://github.com/locomote/translations_checker) that seems to expect only .yml files in locales. So it seems it cannot parse the .rb file and throws an error. (It worked previously because it checks only the files that have been changed - it uses git diff).

# How to test manually
1. Clone the repo and switch to the correct branch:
```
git clone https://github.com/locomote/translations_checker
git checkout story/LM-7416-Update-translations_checker-script-so-it-doesnt-break-when-rb-locale-is-added-changed
```
2. `cd` into TMP
```
cd travel_management_platform
```
3. Make a change in `config/locales/en/date_formats.rb`
4. Commit the changes
```
git add --all
git commit -m "Test"
```
5. Run the script (in TMP directory)
```
bundle exec translations_checker
```
6. There should be an error when you run the script
7. update Gemfile to use the local version of `translations_checker`
Gemfile:
```
gem "translations_checker",
    path: "../relative/path/to/translations_checker",
    require: false
```
8. run bundle
```
bundle install
```
9. Run the script again (in TMP directory)
```
bundle exec translations_checker
```
10. There should be no error

# Solution

Ignore all files but those with .yml extension. We decided to take this (simpler) approach after grooming because another card is blocked by this issue. ([LM-6999](https://locomote.atlassian.net/browse/LM-6999))

# Release notes

translations_checker script now checks only .yml files. Fixed adding and updating dynamic locales in TMP.